### PR TITLE
chore: add package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "copilot-node-server",
+  "version": "1.41.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copilot-node-server",
+      "version": "1.41.0",
+      "license": "GitHub Terms of Service",
+      "bin": {
+        "copilot-node-server": "copilot/dist/language-server.js"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Because this package has no dependency, the package-lock.json is not
really necessary. Still, its presence helps some package maintainers.

Fixes #19.